### PR TITLE
Add Tewr.BlazorWorker.Core Examples

### DIFF
--- a/Benchmark/Pages/AverageCityTemperatures.razor
+++ b/Benchmark/Pages/AverageCityTemperatures.razor
@@ -8,6 +8,10 @@
 @using KristofferStrube.Blazor.Window
 @inject IJSRuntime JSRuntime
 
+<!-- Tewr.BlazorWorker.Core -->
+@using BlazorWorker.Core.CoreInstanceService
+@using BlazorWorker.WorkerCore
+
 <!-- Tewr.BlazorWorker -->
 @using BlazorWorker.BackgroundServiceFactory
 @using BlazorWorker.Core
@@ -88,6 +92,19 @@
 <br />
 <br />
 
+
+
+<button class="btn btn-primary" @onclick=MeasureTewrBlazorWorkerCore>Measure Average Tewr.BlazorWorker.Core</button>
+
+@if (averageTewrBlazorWorkerCore is not null)
+{
+    <text>
+        &nbsp;
+        <span class="badge bg-primary">@Math.Round((decimal)averageTewrBlazorWorkerCore, 3)</span> milliseconds
+    </text>
+}
+<br />
+<br />
 <button class="btn btn-primary" @onclick=MeasureSpawnDevBlazorJSWebWorkers>Measure Average SpawnDev.BlazorJS.WebWorkers</button>
 
 @if (averageSpawnDevBlazorJSWebWorkers is not null)
@@ -109,6 +126,7 @@
     double? averageJSWebWorkers = null;
     double? averageKristofferStrubeBlazorWebWorkers = null;
     double? averageTewrBlazorWorker = null;
+    double? averageTewrBlazorWorkerCore = null;
     double? averageSpawnDevBlazorJSWebWorkers = null;
 
     public async Task MeasureMainThread()
@@ -194,6 +212,8 @@
             .Average();
     }
 
+
+
     public async Task MeasureTewrBlazorWorker()
     {
         averageTewrBlazorWorker = null;
@@ -216,6 +236,60 @@
             .Skip((int)(rounds * skipPart))
             .Average();
     }
+
+    public class AverageCityTemperaturesJobCore : AverageCityTemperaturesJob
+    {
+        private readonly IWorkerMessageService messageService;
+
+        public AverageCityTemperaturesJobCore(IWorkerMessageService messageService, HttpClient httpClient):base(httpClient)
+        {
+            this.messageService = messageService;
+            this.messageService.IncomingMessage += (e, message) =>
+            {
+                this.Work(int.Parse(message))
+                .ContinueWith(t => this.messageService.PostMessageAsync(System.Text.Json.JsonSerializer.Serialize(t.Result)));
+            };
+        }
+    }
+
+
+
+    public async Task MeasureTewrBlazorWorkerCore()
+    {
+        averageTewrBlazorWorkerCore = null;
+        StateHasChanged();
+
+        var worker = await workerFactory.CreateAsync();
+
+        var service = worker.CreateCoreInstanceService();
+        var handle = await service.CreateInstance<AverageCityTemperaturesJobCore>();
+
+        // response synchronizer
+        TaskCompletionSource<CityStatistics[]> nextMessageSource() =>
+            new();
+
+        var nextMessage = nextMessageSource();
+        void OnWorkerMessage(object _, string message) =>
+            nextMessage.SetResult(System.Text.Json.JsonSerializer.Deserialize<CityStatistics[]>(message));
+
+        worker.IncomingMessage += (s, e) => OnWorkerMessage(s, e);
+
+        List<double> measurements = new();
+        for (int i = 0; i < rounds; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            await worker.PostMessageAsync(input.ToString());
+            await nextMessage.Task;
+            nextMessage = nextMessageSource();
+            measurements.Add(Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+        }
+
+        averageTewrBlazorWorkerCore = measurements
+            .OrderDescending()
+            .Skip((int)(rounds * skipPart))
+            .Average();
+    }
+
 
     public async Task MeasureSpawnDevBlazorJSWebWorkers()
     {

--- a/Benchmark/Pages/Home.razor
+++ b/Benchmark/Pages/Home.razor
@@ -7,6 +7,10 @@
 @using KristofferStrube.Blazor.Window
 @inject IJSRuntime JSRuntime
 
+<!-- Tewr.BlazorWorker.Core -->
+@using BlazorWorker.Core.CoreInstanceService
+@using BlazorWorker.WorkerCore
+
 <!-- Tewr.BlazorWorker -->
 @using BlazorWorker.BackgroundServiceFactory
 @using BlazorWorker.Core
@@ -86,7 +90,17 @@
 }
 <br />
 <br />
+<button class="btn btn-primary" @onclick=MeasureTewrBlazorWorkerCore>Measure Average Tewr.BlazorWorker.Core</button>
 
+@if (averageTewrBlazorWorkerCore is not null)
+{
+    <text>
+        &nbsp;
+        <span class="badge bg-primary">@Math.Round((decimal)averageTewrBlazorWorkerCore, 3)</span> milliseconds
+    </text>
+}
+<br />
+<br />
 <button class="btn btn-primary" @onclick=MeasureSpawnDevBlazorJSWebWorkers>Measure Average SpawnDev.BlazorJS.WebWorkers</button>
 
 @if (averageSpawnDevBlazorJSWebWorkers is not null)
@@ -112,6 +126,7 @@
     double? averageJSWebWorkers = null;
     double? averageKristofferStrubeBlazorWebWorkers = null;
     double? averageTewrBlazorWorker = null;
+    double? averageTewrBlazorWorkerCore = null;
     double? averageSpawnDevBlazorJSWebWorkers = null;
 
     public async Task MeasureMainThread()
@@ -219,6 +234,58 @@
         }
 
         averageTewrBlazorWorker = measurements
+            .OrderDescending()
+            .Skip((int)(rounds * skipPart))
+            .Average();
+    }
+
+    public class StringSumJobCore : StringSumJob
+    {
+        private readonly IWorkerMessageService messageService;
+
+        public StringSumJobCore(IWorkerMessageService messageService)
+        {
+            this.messageService = messageService;
+            this.messageService.IncomingMessage += (e, message) =>
+            {
+                var result = this.Work(message);
+                this.messageService.PostMessageAsync(result.ToString());
+            };
+        }
+    }
+
+    public async Task MeasureTewrBlazorWorkerCore()
+    {
+        averageTewrBlazorWorkerCore = null;
+        StateHasChanged();
+
+        var worker = await workerFactory.CreateAsync();
+        var service = worker.CreateCoreInstanceService();
+        var handle = await service.CreateInstance<StringSumJobCore>();
+
+        // response synchronizer
+        TaskCompletionSource<int> nextMessageSource() =>
+            new();
+
+        var nextMessage = nextMessageSource();
+        void OnWorkerMessage(object _, string message) =>
+            nextMessage.SetResult(int.Parse(message));
+
+        worker.IncomingMessage += (s, e) => OnWorkerMessage(s, e);
+
+
+        string[] inputs = Inputs();
+        List<double> measurements = new();
+        for (int i = 0; i < rounds; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            await worker.PostMessageAsync(inputs[i]);
+            await nextMessage.Task;
+            nextMessage = nextMessageSource();
+            measurements.Add(Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+        }
+
+        averageTewrBlazorWorkerCore = measurements
             .OrderDescending()
             .Skip((int)(rounds * skipPart))
             .Average();

--- a/Benchmark/Pages/LargeInput.razor
+++ b/Benchmark/Pages/LargeInput.razor
@@ -98,7 +98,7 @@
 <br />
 <button class="btn btn-primary" @onclick=MeasureTewrBlazorWorkerCore>Measure Average Tewr.BlazorWorker.Core</button>
 
-@if (averageTewrBlazorWorker is not null)
+@if (averageTewrBlazorWorkerCore is not null)
 {
     <text>
         &nbsp;

--- a/Benchmark/Pages/LargeInput.razor
+++ b/Benchmark/Pages/LargeInput.razor
@@ -7,6 +7,10 @@
 @using KristofferStrube.Blazor.Window
 @inject IJSRuntime JSRuntime
 
+<!-- Tewr.BlazorWorker.Core -->
+@using BlazorWorker.Core.CoreInstanceService
+@using BlazorWorker.WorkerCore
+
 <!-- Tewr.BlazorWorker -->
 @using BlazorWorker.BackgroundServiceFactory
 @using BlazorWorker.Core
@@ -92,6 +96,17 @@
 }
 <br />
 <br />
+<button class="btn btn-primary" @onclick=MeasureTewrBlazorWorkerCore>Measure Average Tewr.BlazorWorker.Core</button>
+
+@if (averageTewrBlazorWorker is not null)
+{
+    <text>
+        &nbsp;
+        <span class="badge bg-primary">@Math.Round((decimal)averageTewrBlazorWorkerCore, 3)</span> milliseconds
+    </text>
+}
+<br />
+<br />
 
 <button class="btn btn-primary" @onclick=MeasureSpawnDevBlazorJSWebWorkers>Measure Average SpawnDev.BlazorJS.WebWorkers</button>
 
@@ -125,6 +140,7 @@
     double? averageJSWebWorkers = null;
     double? averageKristofferStrubeBlazorWebWorkers = null;
     double? averageTewrBlazorWorker = null;
+    double? averageTewrBlazorWorkerCore = null;
     double? averageSpawnDevBlazorJSWebWorkers = null;
 
     public async Task MeasureMainThread()
@@ -228,6 +244,56 @@
         }
 
         averageTewrBlazorWorker = measurements
+            .OrderDescending()
+            .Skip((int)(rounds * skipPart))
+            .Average();
+    }
+
+    public class LargeInputJobCore : LargeInputJob
+    {
+        private readonly IWorkerMessageService messageService;
+
+        public LargeInputJobCore(IWorkerMessageService messageService)
+        {
+            this.messageService = messageService;
+            this.messageService.IncomingMessage += (e, message) =>
+            {
+                var result = this.Work(message);
+                this.messageService.PostMessageAsync(result.ToString());
+            };
+        }
+    }
+
+    public async Task MeasureTewrBlazorWorkerCore()
+    {
+        averageTewrBlazorWorkerCore = null;
+        StateHasChanged();
+
+        var worker = await workerFactory.CreateAsync();
+
+        var service = worker.CreateCoreInstanceService();
+        var handle = await service.CreateInstance<LargeInputJobCore>();
+
+        // response synchronizer
+        TaskCompletionSource<int> nextMessageSource() =>
+            new();
+
+        var nextMessage = nextMessageSource();
+        void OnWorkerMessage(object _, string message) =>
+            nextMessage.SetResult(int.Parse(message));
+
+        worker.IncomingMessage += (s, e) => OnWorkerMessage(s, e);
+        List<double> measurements = new();
+        for (int i = 0; i < rounds; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            await worker.PostMessageAsync(inputs[i]);
+            await nextMessage.Task;
+            nextMessage = nextMessageSource();
+            measurements.Add(Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+        }
+
+        averageTewrBlazorWorkerCore = measurements
             .OrderDescending()
             .Skip((int)(rounds * skipPart))
             .Average();

--- a/Benchmark/Pages/SumEvenNumbers.razor
+++ b/Benchmark/Pages/SumEvenNumbers.razor
@@ -92,7 +92,7 @@
 <br />
 <br />
 
-<button class="btn btn-primary" @onclick=MeasureTewrBlazorWorkerCore>Measure Average Tewr.BlazorWorkerCore</button>
+<button class="btn btn-primary" @onclick=MeasureTewrBlazorWorkerCore>Measure Average Tewr.BlazorWorker.Core</button>
 
 @if (averageTewrBlazorWorkerCore is not null)
 {
@@ -257,7 +257,7 @@
         var worker = await workerFactory.CreateAsync();
         // response synchronizer
         TaskCompletionSource<int> nextMessageSource() => 
-            new TaskCompletionSource<int>();
+            new();
 
         var nextMessage = nextMessageSource();
         void OnWorkerMessage(object _, string message) =>
@@ -266,12 +266,12 @@
         worker.IncomingMessage += (s, e) => OnWorkerMessage(s ,e);
 
         var service = worker.CreateCoreInstanceService();
+        var handle = await service.CreateInstance<SumEvenNumbersJobCore>();
 
         List<double> measurements = new();
         for (int i = 0; i < rounds; i++)
         {
             long start = Stopwatch.GetTimestamp();
-            //var localParameterValue = input;
             await worker.PostMessageAsync(input.ToString());
             await nextMessage.Task;
             nextMessage = nextMessageSource();

--- a/Benchmark/Pages/SumEvenNumbers.razor
+++ b/Benchmark/Pages/SumEvenNumbers.razor
@@ -7,10 +7,15 @@
 @using KristofferStrube.Blazor.Window
 @inject IJSRuntime JSRuntime
 
+<!-- Tewr.BlazorWorker.Core -->
+@using BlazorWorker.Core.CoreInstanceService
+@using BlazorWorker.WorkerCore
+
 <!-- Tewr.BlazorWorker -->
 @using BlazorWorker.BackgroundServiceFactory
 @using BlazorWorker.Core
 @inject IWorkerFactory workerFactory
+
 
 <!-- SpawnDev.BlazorJS.WebWorkers -->
 @using SpawnDev.BlazorJS.WebWorkers
@@ -87,6 +92,18 @@
 <br />
 <br />
 
+<button class="btn btn-primary" @onclick=MeasureTewrBlazorWorkerCore>Measure Average Tewr.BlazorWorkerCore</button>
+
+@if (averageTewrBlazorWorkerCore is not null)
+{
+    <text>
+        &nbsp;
+        <span class="badge bg-primary">@Math.Round((decimal)averageTewrBlazorWorkerCore, 3)</span> milliseconds
+    </text>
+}
+<br />
+<br />
+
 <button class="btn btn-primary" @onclick=MeasureSpawnDevBlazorJSWebWorkers>Measure Average SpawnDev.BlazorJS.WebWorkers</button>
 
 @if (averageSpawnDevBlazorJSWebWorkers is not null)
@@ -108,6 +125,7 @@
     double? averageJSWebWorkers = null;
     double? averageKristofferStrubeBlazorWebWorkers = null;
     double? averageTewrBlazorWorker = null;
+    double? averageTewrBlazorWorkerCore = null;
     double? averageSpawnDevBlazorJSWebWorkers = null;
 
     public async Task MeasureMainThread()
@@ -211,6 +229,56 @@
         }
 
         averageTewrBlazorWorker = measurements
+            .OrderDescending()
+            .Skip((int)(rounds * skipPart))
+            .Average();
+    }
+
+    public class SumEvenNumbersJobCore : SumEvenNumbersJob
+    {
+        private readonly IWorkerMessageService messageService;
+
+        public SumEvenNumbersJobCore(IWorkerMessageService messageService)
+        {
+            this.messageService = messageService;
+            this.messageService.IncomingMessage += (e, message) =>
+            {
+                var result = this.Work(int.Parse(message));
+                this.messageService.PostMessageAsync(result.ToString());
+            };
+        }
+    }
+
+    public async Task MeasureTewrBlazorWorkerCore()
+    {
+        averageTewrBlazorWorkerCore = null;
+        StateHasChanged();
+
+        var worker = await workerFactory.CreateAsync();
+        // response synchronizer
+        TaskCompletionSource<int> nextMessageSource() => 
+            new TaskCompletionSource<int>();
+
+        var nextMessage = nextMessageSource();
+        void OnWorkerMessage(object _, string message) =>
+            nextMessage.SetResult(int.Parse(message));
+        
+        worker.IncomingMessage += (s, e) => OnWorkerMessage(s ,e);
+
+        var service = worker.CreateCoreInstanceService();
+
+        List<double> measurements = new();
+        for (int i = 0; i < rounds; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            //var localParameterValue = input;
+            await worker.PostMessageAsync(input.ToString());
+            await nextMessage.Task;
+            nextMessage = nextMessageSource();
+            measurements.Add(Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+        }
+
+        averageTewrBlazorWorkerCore = measurements
             .OrderDescending()
             .Skip((int)(rounds * skipPart))
             .Average();

--- a/Benchmark/Pages/Tewr.razor
+++ b/Benchmark/Pages/Tewr.razor
@@ -15,7 +15,7 @@
     {
         IWorker worker = await workerFactory.CreateAsync();
         var service = await worker.CreateBackgroundServiceAsync<MathService>();
-
+        
         double input = Random.Shared.NextDouble();
 
         double output = await service.RunAsync(math => math.MutliplyByTwo(input));

--- a/Benchmark/Pages/TewrCore.razor
+++ b/Benchmark/Pages/TewrCore.razor
@@ -1,0 +1,53 @@
+﻿@page "/TewrCore"
+
+@using BlazorWorker.Core.CoreInstanceService
+@using BlazorWorker.Core
+@using BlazorWorker.WorkerCore
+@inject IWorkerFactory workerFactory
+
+<button @onclick=ExecuteOnTewrBlazorWorker>Execute</button>
+<br/>
+<code>@result</code>
+
+@code {
+    private string result = "";
+    private IInstanceHandle coreMathService;
+    private double lastInput;
+    private async Task ExecuteOnTewrBlazorWorker()
+    {
+        IWorker worker = await workerFactory.CreateAsync();
+        worker.IncomingMessage += this.OnWorkerMessage;
+
+        var service = worker.CreateCoreInstanceService();
+        coreMathService = await service.CreateInstance<MathServiceCore>();
+
+        double input = Random.Shared.NextDouble();
+        lastInput = input;
+        await worker.PostMessageAsync(input.ToString());
+
+        //double output = await service.RunAsync(math => math.MutliplyByTwo(input));
+
+
+    }
+
+    public void OnWorkerMessage(object sender, string message)
+    {
+        result = $"{lastInput} * 2 = {message}";
+        StateHasChanged();
+    }
+
+    public class MathServiceCore : MathService
+    {
+        private readonly IWorkerMessageService messageService;
+
+        public MathServiceCore(IWorkerMessageService messageService)
+        {
+            this.messageService = messageService;
+            this.messageService.IncomingMessage += (e, message) =>
+            {
+                var result = this.MutliplyByTwo(double.Parse(message));
+                this.messageService.PostMessageAsync(result.ToString());
+            };
+        }
+    }
+}


### PR DESCRIPTION
Hello,

I read your article and I think it was interesting. My library has a "Core" mode that can be used that does not use any serializer. So it's a lot more contrived to use, but i'ts comparable in speed to the other examples in your article, that's why I thought it could be interesting to add it to your comparison. 

Regards